### PR TITLE
chore: crowdin.yml make fastlane metadata translatable

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -35,3 +35,9 @@ files:
     translation: /ui-lib/src/main/res/ui/wallet_address/values-%two_letters_code%/strings.xml
   - source: /ui-lib/src/main/res/ui/warning/values/strings.xml
     translation: /ui-lib/src/main/res/ui/warning/values-%two_letters_code%/strings.xml
+  - source: /fastlane/metadata/android/en-US/full_description.txt
+    translation: /fastlane/metadata/android/%locale%/full_description.txt
+  - source: /fastlane/metadata/android/en-US/short_description.txt
+    translation: /fastlane/metadata/android/%locale%/short_description.txt
+  - source: /fastlane/metadata/android/en-US/title.txt
+    translation: /fastlane/metadata/android/%locale%/title.txt


### PR DESCRIPTION
To make the app description translatable the files inside of the `fastlane` directory needs to be added in Crowdin.
During the next release the F-Droid will peak the new translations.

BTW other apps use `%android_code%` for the `values-*` like here:
```yaml
files:
  - source: /app/src/main/res/values/strings.xml
    translation: /app/src/main/res/values-%android_code%/%original_file_name%
```